### PR TITLE
Added option to reset the infinite loader

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -92,6 +92,12 @@
         this.isNoMore = true;
         this.scrollParent.removeEventListener('scroll', this.scrollHandler);
       },
+      '$InfiniteLoading:reset'() {
+        this.isLoading = false;
+        this.isNoMore = false;
+        this.isNoResults = false;
+        this.scrollParent.addEventListener('scroll', this.scrollHandler);
+      },
     },
     destroyed() {
       if (!this.isNoResults && !this.isNoMore) {

--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -97,6 +97,8 @@
         this.isNoMore = false;
         this.isNoResults = false;
         this.scrollParent.addEventListener('scroll', this.scrollHandler);
+        
+        this.scrollHandler();
       },
     },
     destroyed() {


### PR DESCRIPTION
When using the infinite scroll there is no ability to reset the scroll element. This can be useful when you are using the infinite scroll to show results based on filters. 

1. If you apply filter A and scroll till the end the message no more data is shown. 
2. But if you also apply filter B and start over again with the list then the "no more data" message is still being shown and the scroll don't work anymore. If you can fire the reset event it will 'reload' the infinite scroll element.