### PR TITLE
Added update to handle low number of initial items

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -50,7 +50,9 @@
             }
 
             this.list = this.list.concat(temp);
-            this.$broadcast('$InfiniteLoading:loaded');
+            this.$nextTick(function () {
+              this.$broadcast('$InfiniteLoading:loaded');
+            });
           }.bind(this), 1000);
         }
       }

--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -84,10 +84,8 @@
       this.scrollParent = getScrollParent(this.$el);
 
       this.scrollHandler = function scrollHandlerOriginal() {
-        const currentDistance = getCurrentDistance(this.scrollParent);
-        if (!this.isLoading && currentDistance <= this.distance) {
-          this.isLoading = true;
-          this.onInfinite.call();
+        if (!this.isLoading) {
+          this.attemptLoad();
         }
       }.bind(this);
 
@@ -96,8 +94,10 @@
     },
     events: {
       '$InfiniteLoading:loaded': function loaded() {
-        this.isLoading = false;
         this.isFirstLoad = false;
+        if (this.isLoading) {
+          this.attemptLoad();
+        }
       },
       '$InfiniteLoading:complete': function complete() {
         this.isLoading = false;
@@ -110,6 +110,17 @@
         this.isFirstLoad = true;
         this.scrollParent.addEventListener('scroll', this.scrollHandler);
         setTimeout(this.scrollHandler, 1);
+      },
+    },
+    methods: {
+      attemptLoad() {
+        const currentDistance = getCurrentDistance(this.scrollParent);
+        if (!this.isComplete && currentDistance <= this.distance) {
+          this.isLoading = true;
+          this.onInfinite.call();
+        } else {
+          this.isLoading = false;
+        }
       },
     },
     destroyed() {


### PR DESCRIPTION
Added the logic to handle the case where the initial batch of loaded items doesn't fully fill the parent and does not cause overflow. Added test case that validates the changes.

Please not that the override of `onInfinite` must now emit `loaded` and `completed` events from within the `nextTick` such as:

```
onInfinite: function () {
	var temp = [];
	for (var i = this.list.length; i <= this.list.length + 20; i++) {
		temp.push(i);
	}

	this.list = this.list.concat(temp);
	this.$nextTick(function () {
		this.$broadcast('$InfiniteLoading:loaded');
	});
);
```

That is required because Vue guarantees that the items will have been added to the list in the next tick. This is important for calculation of distance. If `loaded` is not called from within `nextTick`, the list elements haven't yet been added and will result in an infinite loop.

Once you add the logic to handle stagger, this limitation will go away as `onInfinite` will always be called after stagger completes and all items added.

Let me know if you have any questions.