### PR TITLE
Fix #43: Infinite loading tables

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -50,11 +50,14 @@
     if (dir === 'top') {
       distance = scrollTop;
     } else {
+      const elmBoundingClientRect = elm.getBoundingClientRect();
       const scrollElmHeight = elm === window ?
                               window.innerHeight :
-                              elm.getBoundingClientRect().height;
+                              elmBoundingClientRect.height;
+      const elOffsetTopFromScrollElm = this.$el.getBoundingClientRect().top -
+                                       elmBoundingClientRect.top;
 
-      distance = this.$el.offsetTop - scrollTop - scrollElmHeight - (elm.offsetTop || 0);
+      distance = elOffsetTopFromScrollElm - scrollTop - scrollElmHeight - (elm.offsetTop || 0);
     }
     return distance;
   }


### PR DESCRIPTION
`this.$el.offsetTop` will always evaluate to 0 when `this.$el` is inside a `td` (but the scrolling element is a `table`). This causes the `distance` to keep decreasing and the component continuously calls `onInfinite`.

This PR fixes the issue by explicitly calculating the top offset of `this.$el`, relative to the actual scrolling element, and not just the direct parent.

I tried to see if `this.$el.offsetTop` will be updated by just setting CSS `position` to `relative` on `tr`, `td`, and `this.$el`, and all combinations, but no luck there. The performance hit of this PR  will be an extra `getBoundingClientRect` call for `this.$el`.