### PR TITLE
Fixes #43: Patch distance calculation bug

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -46,22 +46,22 @@
    */
   function getCurrentDistance(elm, dir) {
     let distance;
-    const scrollTop = isNaN(elm.scrollTop) ? elm.pageYOffset : elm.scrollTop;
+
     if (dir === 'top') {
-      distance = scrollTop;
+      distance = isNaN(elm.scrollTop) ? elm.pageYOffset : elm.scrollTop;
     } else {
       let scrollElmHeight;
-      let elOffsetTopFromScrollElm = this.$el.getBoundingClientRect().top;
+      let elOffsetTop = this.$el.getBoundingClientRect().top;
 
       if (elm === window) {
         scrollElmHeight = window.innerHeight;
       } else {
-        scrollElmHeight = elm.getBoundingClientRect().height;
-        elOffsetTopFromScrollElm -= elm.getBoundingClientRect().top;
+        scrollElmHeight = elm.clientHeight;
+        elOffsetTop -= elm.getBoundingClientRect().top;
       }
-
-      distance = elOffsetTopFromScrollElm - scrollElmHeight - (elm.offsetTop || 0);
+      distance = elOffsetTop - scrollElmHeight;
     }
+
     return distance;
   }
 


### PR DESCRIPTION
Fixes bug that was introduced in PR https://github.com/PeachScript/vue-infinite-loading/pull/48, and released in (now deprecated) 2.1.1.