### PR TITLE
Fixes #49: Debounce scroll event handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,8 @@
   "license": "MIT",
   "pre-commit": [
     "lint"
-  ]
+  ],
+  "dependencies": {
+    "lodash.debounce": "^4.0.8"
+  }
 }


### PR DESCRIPTION
Also removed both calls to `bind`:
- by declaring `getCurrentDistance` as a method (since it was using `this.$el` anyway)
- by moving `scrollHandler` as a debounced method