### PR TITLE
add name attribute to InfiniteLoading component

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -59,6 +59,7 @@
   };
 
   export default {
+    name: 'InfiniteLoading',
     data() {
       return {
         scrollParent: null,


### PR DESCRIPTION
Hello,

Using vue-test-utils, we need the **name** attribute to be set on the component if we want to find it in the template.

For example : 
```
it('should contain infinite loading component', () => {
      // when
      const wrapper = shallow(LatestNews);

      // then
      const infiniteLoadingComponents = wrapper.findAll(InfiniteLoading);
      expect(infiniteLoadingComponents.length).toEqual(1);
});
```

Thank you