### PR TITLE
Manual Initialization

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -78,6 +78,11 @@
       Spinner,
     },
     computed: {
+      isInit: {
+        get() {
+          return this.init;
+        }
+      },
       isNoResults: {
         cache: false, // disable cache to fix the problem of get slot text delay
         get() {
@@ -98,6 +103,10 @@
       },
     },
     props: {
+      init: {
+        type: Boolean,
+        default: null
+      },
       distance: {
         type: Number,
         default: 100,
@@ -109,6 +118,13 @@
         default: 'bottom',
       },
       forceUseInfiniteWrapper: null,
+    },
+    watch: {
+      init: function(isReady) {
+        if (isReady) {
+          this.initInfinity();
+        }
+      }
     },
     mounted() {
       this.scrollParent = this.getScrollParent();
@@ -125,7 +141,10 @@
         }
       }.bind(this);
 
-      setTimeout(this.scrollHandler, 1);
+      if (this.init === null) {
+        setTimeout(this.scrollHandler, 1);
+      }
+
       this.scrollParent.addEventListener('scroll', this.scrollHandler);
 
       this.$on('$InfiniteLoading:loaded', (ev) => {
@@ -201,6 +220,12 @@
       this.scrollParent.addEventListener('scroll', this.scrollHandler);
     },
     methods: {
+      /**
+       * initialize the component manually if 'init' property is present
+       */
+      initInfinity() {
+        setTimeout(this.scrollHandler, 1);
+      },
       /**
       * attempt trigger load
       * @param {Boolean} isContinuousCall  the flag of continuous call, it will be true


### PR DESCRIPTION
Added new feature for manual initialization, solves the problem in the following scenario:
Application loads initialization data asynchronously from the API or any back-end environment => fetched content does not fill the entire user's screen => no more content is fetched and there is no scroll bar because height check was executed before the response from the server.

Using this new component property, you can initialize the functioning of scroll manually and independently.

Usage:
`<InfiniteLoading @infinite="infiniteHandler" :init="false"></InfiniteLoading>`

once the initialization calls have finished you can dynamically change the property to:
`<InfiniteLoading @infinite="infiniteHandler" :init="true"></InfiniteLoading>`

If there is no :init property the code will work as usual.