### PR TITLE
add 'hideSpinnerAfterLoaded' prop

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="infinite-loading-container">
-    <div v-show="isLoading">
+    <div v-show="showSpinner">
       <slot name="spinner">
         <spinner :spinner="spinner" />
       </slot>
@@ -96,6 +96,10 @@
           return !this.isLoading && this.isComplete && !this.isFirstLoad && !isBlankNoMoreSlot;
         },
       },
+      showSpinner() {
+          // in case that APP in UIWebview cannot show the spinner when scrolling to bottom
+          return this.hideSpinner ? this.loading : (!this.isNoMore && !this.isNoResults)
+      }
     },
     props: {
       distance: {
@@ -104,6 +108,10 @@
       },
       onInfinite: Function,
       spinner: String,
+      hideSpinner: {
+          type: Boolean,
+          default: true
+      },
       direction: {
         type: String,
         default: 'bottom',

--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -98,7 +98,7 @@
       },
       showSpinner() {
           // in case that APP in UIWebview cannot show the spinner when scrolling to bottom
-          return this.hideSpinnerAfterLoaded ? this.loading : (!this.isNoMore && !this.isNoResults);
+          return this.hideSpinnerAfterLoaded ? this.isLoading : (!this.isNoMore && !this.isNoResults);
       },
     },
     props: {

--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -98,7 +98,7 @@
       },
       showSpinner() {
           // in case that APP in UIWebview cannot show the spinner when scrolling to bottom
-          return this.hideAfterLoaded ? this.loading : (!this.isNoMore && !this.isNoResults);
+          return this.hideSpinnerAfterLoaded ? this.loading : (!this.isNoMore && !this.isNoResults);
       },
     },
     props: {
@@ -108,7 +108,7 @@
       },
       onInfinite: Function,
       spinner: String,
-      hideAfterLoaded: {
+      hideSpinnerAfterLoaded: {
           type: Boolean,
           default: true,
       },

--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -98,7 +98,7 @@
       },
       showSpinner() {
           // in case that APP in UIWebview cannot show the spinner when scrolling to bottom
-          return this.hideSpinner ? this.loading : (!this.isNoMore && !this.isNoResults);
+          return this.hideAfterLoaded ? this.loading : (!this.isNoMore && !this.isNoResults);
       },
     },
     props: {
@@ -108,7 +108,7 @@
       },
       onInfinite: Function,
       spinner: String,
-      hideSpinner: {
+      hideAfterLoaded: {
           type: Boolean,
           default: true,
       },

--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -98,8 +98,8 @@
       },
       showSpinner() {
           // in case that APP in UIWebview cannot show the spinner when scrolling to bottom
-          return this.hideSpinner ? this.loading : (!this.isNoMore && !this.isNoResults)
-      }
+          return this.hideSpinner ? this.loading : (!this.isNoMore && !this.isNoResults);
+      },
     },
     props: {
       distance: {
@@ -110,7 +110,7 @@
       spinner: String,
       hideSpinner: {
           type: Boolean,
-          default: true
+          default: true,
       },
       direction: {
         type: String,


### PR DESCRIPTION
In UIWebview, the app cannot show the spinner immediately when scrolling to bottom. This is because the UIWebview prevents all of the render caused by DOM changing or scripts. on this condition, it is necessary to keep the spinner showing at the bottom  of the list until 'isNoMore' or 'isNoResults' is true.
--------------------------------------
UIWebView在进行momentum scrolling(弹性滚动)时,会停止所有的事件响应 及 DOM操作引起的页面渲染，故 onscroll 不能实时响应。这就导致了我们滑动到页面底部的时候看不见 spinner。这时候就需要让 spinner 处于list 底部且保持可见的状态直到 'isNoMore' 或者 'isNoResults' 二者有其一变为 true。这样滑动到底部就可以直接看见 spinner 了。