### PR TITLE
Update InfiniteLoading.vue

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -146,6 +146,7 @@
       });
 
       this.$on('$InfiniteLoading:complete', (ev) => {
+        this.isFirstLoad = false;
         this.isLoading = false;
         this.isComplete = true;
 


### PR DESCRIPTION
Imagine that the **page 1 is the last page**. We should normally use the `complete()` trigger method. Problem is that `isFirstLoad `is not set to false in this case.

### Cause this problem
`No more results :(` is displayed instead of `No more data :)`