### PR TITLE
feat: add failed state

### DIFF
--- a/test/unit/specs/InfiniteLoading.spec.js
+++ b/test/unit/specs/InfiniteLoading.spec.js
@@ -369,7 +369,7 @@ describe('vue-infinite-loading', () => {
     vm = new Vue(Object.assign({}, basicConfig, {
       methods: {
         infiniteHandler: function infiniteHandler($state) {
-          if (calledTimes) {
+          if (calledTimes === 1) {
             $state.loaded();
             $state.complete();
             this.$nextTick(() => {
@@ -377,7 +377,7 @@ describe('vue-infinite-loading', () => {
               expect(isShow(this.$el.querySelectorAll('.infinite-status-prompt')[1])).to.be.false;
               done();
             });
-          } else {
+          } else if (calledTimes === 0) {
             calledTimes += 1;
             $state.complete();
             this.$nextTick(() => {
@@ -386,6 +386,11 @@ describe('vue-infinite-loading', () => {
 
               // reset component to check no-more status
               $state.reset();
+            });
+          } else {
+            $state.failed();
+            this.$nextTick(() => {
+              expect(isShow(this.$el.querySelectorAll('.infinite-status-prompt')[3])).to.be.false;
             });
           }
         },
@@ -397,6 +402,7 @@ describe('vue-infinite-loading', () => {
           >
           <span slot="no-results"></span>
           <span slot="no-more"></span>
+          <span slot="is-failed"></span>
         </infinite-loading>
       `,
     }));
@@ -561,6 +567,24 @@ describe('vue-infinite-loading', () => {
           expect(this.$refs.infiniteLoading.scrollParent).to.equal(this.$el.querySelector('div'));
           done();
         });
+      },
+    }));
+
+    vm.$mount('#app');
+  });
+
+  it('should call state.$failed() show failed slot', (done) => {
+    vm = new Vue(Object.assign({}, basicConfig, {
+      methods: {
+        infiniteHandler: function infiniteHandler($state) {
+          $state.failed();
+
+          this.$nextTick(() => {
+            // check failed text
+            expect(isShow(this.$el.querySelectorAll('.infinite-status-prompt')[2])).to.be.true;
+            done();
+          });
+        },
       },
     }));
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,6 +14,7 @@ declare namespace InfiniteLoading {
     spinner: VNode[];
     'no-result': VNode[];
     'no-more': VNode[];
+    'is-failed':VNode[];
     [key: string]: VNode[];
   }
 
@@ -21,6 +22,7 @@ declare namespace InfiniteLoading {
     loaded(): void;
     complete(): void;
     reset(): void;
+    failed():void;
   }
 }
 


### PR DESCRIPTION
Hi,awesome lib. 
I add this feature to enable the lib to support display a failed component when there is a network or request error. we can use $state.failed() to show the is-failed component just like no-result and no-more;