### PR TITLE
Fix InfiniteLoading Plugin in typescript

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Phil Scott <https://github.com/enkafan>
 //                 PeachScript <https://github.com/PeachScript>
 
-import Vue, { VNode, Component } from 'vue';
+import Vue, { VNode, Component, PluginFunction } from 'vue';
 
 export type SpinnerType = 'default' | 'bubbles' | 'circles' | 'spiral' | 'waveDots';
 export type DirectionType = 'top' | 'bottom';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -64,5 +64,7 @@ export default class InfiniteLoading extends Vue {
 
   // Slots
   $slots: Slots;
+  
+  static install: PluginFunction<never>;
 }
 


### PR DESCRIPTION
Without the install function typescript get an error like this:
`Argument of type 'typeof InfiniteLoading' is not assignable to parameter of type 'PluginObject<{ props: { spinner: string; }; system: { throttleLimit: number; }; }> | PluginFunction<{ props: { spinner: string; }; system: { throttleLimit: number; }; }>'.   Property 'install' is missing in type 'typeof InfiniteLoading' but required in type 'PluginObject<{ props: { spinner: string; }; system: { throttleLimit: number; }; }>'.`
