### PR TITLE
fix: continuously trigger scroll if spinner slot is bigger than scrollParent in Chrome

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -118,6 +118,10 @@ export default {
     },
   },
   props: {
+    keepScrollTop: {
+      type: Boolean,
+      default: false,
+    },
     distance: {
       type: Number,
       default: config.props.distance,
@@ -171,6 +175,13 @@ export default {
 
       if (this.status === STATUS.LOADING) {
         this.$nextTick(this.attemptLoad.bind(null, true));
+      }
+
+      if (this.keepScrollTop) {
+        const scrollTop = this.getScrollParentOffset();
+        this.$nextTick(() => {
+          this.setScrollParentOffset(scrollTop);
+        });
       }
 
       if (!ev || ev.target !== this) {
@@ -328,6 +339,19 @@ export default {
       }
 
       return result || this.getScrollParent(elm.parentNode);
+    },
+    getScrollParentOffset() {
+      const scrollParent = this.getScrollParent();
+      return (scrollParent === window
+        ? document.documentElement.scrollTop
+        : scrollParent.scrollTop
+      );
+    },
+    setScrollParentOffset(scrollTop) {
+      (this.scrollParent === window
+        ? document.documentElement
+        : this.scrollParent
+      ).scrollTop = scrollTop;
     },
   },
   destroyed() {


### PR DESCRIPTION
[DEMO](https://jsfiddle.net/zn6vxugd/)
## How to Reproduce
Open the demo in Chrome,  wait until the first loading complete. Then scroll to bottom quickly so that the spinner covers the container, you will found it continuously loading data until all data complete.
## Description
Generally, the vue-infinite-loading component will be 'pushed' out of viewport as data loading.  But if it is bigger than the container, for example, if I use a spinner slot whose height is bigger than the container, it will never be pushed out of viewport until all data complete.
Safari works fine as the scrollTop of container keeps unchanged in this case.
## How to Fix
Add an option to reset the scrollTop attribute of the container after loading.