### PR TITLE
fix: Safari scrollTop

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -76,7 +76,7 @@ export const loopTracker = {
 export const scrollBarStorage = {
   key: '_infiniteScrollHeight',
   getScrollElm(elm) {
-    return elm === window ? document.documentElement : elm;
+    return elm === window ? (document.scrollElement || document.documentElement) : elm;
   },
   save(elm) {
     const target = this.getScrollElm(elm);

--- a/src/utils.js
+++ b/src/utils.js
@@ -76,7 +76,7 @@ export const loopTracker = {
 export const scrollBarStorage = {
   key: '_infiniteScrollHeight',
   getScrollElm(elm) {
-    return elm === window ? (document.scrollElement || document.documentElement) : elm;
+    return elm === window ? (document.scrollingElement || document.documentElement) : elm;
   },
   save(elm) {
     const target = this.getScrollElm(elm);


### PR DESCRIPTION
`direction="top"` on Safari was not preserving scroll after prepending new items because `scrollTop` is always 0 on the body in Safari.
Tracked it down to this small little tweak.
Tested on Chrome and Safari.