### PR TITLE
Changes name casing in Vue.component calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ Object.defineProperty(InfiniteLoading, 'install', {
     Object.assign(config.system, options && options.system);
 
     // register component
-    Vue.component('infinite-loading', InfiniteLoading);
+    Vue.component('InfiniteLoading', InfiniteLoading);
 
     syncModeFromVue(Vue);
   },
@@ -28,7 +28,7 @@ Object.defineProperty(InfiniteLoading, 'install', {
 // register component automatically if there has global Vue
 /* istanbul ignore else */
 if (typeof window !== 'undefined' && window.Vue) {
-  window.Vue.component('infinite-loading', InfiniteLoading);
+  window.Vue.component('InfiniteLoading', InfiniteLoading);
   syncModeFromVue(window.Vue);
 }
 


### PR DESCRIPTION
Due to the casing of the component name given to Vue.component, the component can only be used in templates as `<infinite-loading>`, and never `<InfiniteLoading>`.
Changing the casing allows both `<infinite-loading>` and `<InfiniteLoading>` to be used in templates.

I could not get the tests to run without fail, even before I made any changes.
I followed the development setup guide in `CONTRIBUTING.md`.
The failing tests are the same before and after the changes were made.

Nevertheless, this is a very minor change, and it doesn't affect anything negatively.