### PR TITLE
getScrollParent window

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -316,7 +316,11 @@ export default {
       let result;
 
       if (typeof this.forceUseInfiniteWrapper === 'string') {
-        result = elm.querySelector(this.forceUseInfiniteWrapper);
+        if (this.forceUseInfiniteWrapper === 'window') {
+          result = window;
+        } else {
+          result = elm.querySelector(this.forceUseInfiniteWrapper);
+        }
       }
 
       if (!result) {


### PR DESCRIPTION
If you use the infinity wrapper inside of a webcomponent and you want to target the window, you need to skip the querySelector. The vue element can not query things outside of the webcomponent. This is a very specific check. However, it also doesn't break anything.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/PeachScript/vue-infinite-loading/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
