### PR TITLE
fix #254: 

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -320,7 +320,7 @@ export default {
       }
 
       if (!result) {
-        if (elm.tagName === 'BODY') {
+        if (elm.tagName === 'BODY' || !elm.parentNode) {
           result = window;
         } else if (!this.forceUseInfiniteWrapper && ['scroll', 'auto'].indexOf(getComputedStyle(elm).overflowY) > -1) {
           result = elm;


### PR DESCRIPTION
sometimes when using nuxt the elm.parentNode is null and vue-infinite-loading makes error

this is a simple fix to set scrollparent to window if elm.parentNode is null

#254
