### PR TITLE
fix: PluginFunction type is not assignable to type options

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -65,6 +65,6 @@ export default class InfiniteLoading extends Vue {
   // Slots
   $slots: Slots;
   
-  static install: PluginFunction<never>;
+  static install: PluginFunction<InfiniteOptions>;
 }
 


### PR DESCRIPTION
## How to reproduce

app.ts
```javascript
Vue.use(InfiniteLoading, {
    slots: {
        noMore: '',
        error: '',
    },
});
```

TypeScript terminal
```bash
No overload matches this call.
  Overload 2 of 2, '(plugin: PluginObject<any> | PluginFunction<any>, ...options: any[]): VueConstructor<Vue>', gave the following error.
    Argument of type 'typeof InfiniteLoading' is not assignable to parameter of type 'PluginObject<any> | PluginFunction<any>'.
      Type 'typeof InfiniteLoading' is not assignable to type 'PluginObject<any>'.
        Types of property 'install' are incompatible.
          Type 'PluginFunction<never>' is not assignable to type 'PluginFunction<any>'.
            Type 'any' is not assignable to type 'never'.
```

## How to fix

- fix plugin install with assignable options type `PluginFunction<never>` to `PluginFunction<InfiniteOptions>`