### PR TITLE
feat: add prop to forcefully use body wrapper

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -127,6 +127,10 @@ export default {
       type: String,
       default: 'bottom',
     },
+    forceBodyWrapper: {
+      type: Boolean,
+      default: false,
+    },
     forceUseInfiniteWrapper: {
       type: [Boolean, String],
       default: config.props.forceUseInfiniteWrapper,
@@ -320,6 +324,10 @@ export default {
       }
 
       if (!result) {
+        if (this.forceBodyWrapper) {
+          return document.body;
+        }
+
         if (elm.tagName === 'BODY') {
           result = window;
         } else if (!this.forceUseInfiniteWrapper && ['scroll', 'auto'].indexOf(getComputedStyle(elm).overflowY) > -1) {

--- a/test/unit/specs/InfiniteLoading.spec.js
+++ b/test/unit/specs/InfiniteLoading.spec.js
@@ -31,7 +31,7 @@ describe('vue-infinite-loading:component', () => {
     `,
     components: { InfiniteLoading },
     methods: {
-      infiniteHandler() {},
+      infiniteHandler() { },
     },
   };
 
@@ -521,6 +521,37 @@ describe('vue-infinite-loading:component', () => {
           expect(this.$refs.infiniteLoading.scrollParent).to.equal(this.$el.querySelector('div'));
           done();
         });
+      },
+    }));
+
+    vm.$mount('#app');
+  });
+
+  it('should use HTMLBodyElement when using forceBodyWrapper', (done) => {
+    vm = new Vue(Object.assign({}, basicConfig, {
+      template: `
+        <div class="scroll">
+          <div style="overflow: auto;">
+            <div style="overflow: auto;">
+              <ul>
+                <li v-for="item in list" v-text="item"></li>
+              </ul>
+              <infinite-loading
+                :direction="direction"
+                @infinite="infiniteHandler"
+                ref="infiniteLoading"
+                :forceBodyWrapper="true"
+                >
+              </infinite-loading>
+            </div>
+          </div>
+        </div>
+      `,
+      methods: {
+        infiniteHandler: function infiniteHandler() {
+          expect(this.$refs.infiniteLoading.scrollParent.tagName).to.equal('BODY');
+          done();
+        },
       },
     }));
 


### PR DESCRIPTION
Add a prop which enables the use of HTMLBody Element as a wrapper.

In one of my projects in order to disable default scroll from Safari, I had to use `overflow: scroll` for the body and when I want to use it as an infinite loader a check is made when using "body" and it fallbacks to Window. 

This pull request adds a prop which enables the usage of "body".