### PR TITLE
fix: replace v-show to v-if in order to use it with all types of vue components

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -2,7 +2,7 @@
   <div class="infinite-loading-container">
     <div
       class="infinite-status-prompt"
-      v-show="isShowSpinner"
+      v-if="isShowSpinner"
       :style="slotStyles.spinner">
       <slot name="spinner" v-bind="{ isFirstLoad }">
         <spinner :spinner="spinner" />
@@ -11,7 +11,7 @@
     <div
       class="infinite-status-prompt"
       :style="slotStyles.noResults"
-      v-show="isShowNoResults">
+      v-if="isShowNoResults">
       <slot name="no-results">
         <component v-if="slots.noResults.render" :is="slots.noResults"></component>
         <template v-else>{{ slots.noResults }}</template>
@@ -20,7 +20,7 @@
     <div
       class="infinite-status-prompt"
       :style="slotStyles.noMore"
-      v-show="isShowNoMore">
+      v-if="isShowNoMore">
       <slot name="no-more">
         <component v-if="slots.noMore.render" :is="slots.noMore"></component>
         <template v-else>{{ slots.noMore }}</template>
@@ -29,7 +29,7 @@
     <div
       class="infinite-status-prompt"
       :style="slotStyles.error"
-      v-show="isShowError">
+      v-if="isShowError">
       <slot name="error" :trigger="attemptLoad">
         <component
           v-if="slots.error.render"


### PR DESCRIPTION
Using `v-show` directive for hiding slots can cause some issues, for example, if you have a modal content for loader provided by vue-portal it can't be hidden just with `display: none` ( v-show ). In such cases it's important to use `v-if` directive.

This code won't work if I'll use `vue-portal` because portals can't be hidden via `v-show` and as the result - we will see a modal all the time on a screen.
```js
<InfiniteLoading @infinite="infinite">
    <template v-slot:spinner>
        <VuePortalModalLoader></VuePortalModalLoader> // <--- This component will be never hidden because of v-show
    </template>
</InfiniteLoading>
```

This issue can be fixed replacing all `v-show`'s which are using to hide slot content to `v-if` directives.