### PR TITLE
fix minor typo

### DIFF
--- a/docs/guide/use-with-el-table.md
+++ b/docs/guide/use-with-el-table.md
@@ -31,4 +31,4 @@ The final template should be similar to:
 </div>
 ```
 
-No special handling is required in the logic. This plugin should alread work, just like the preview on the right!
+No special handling is required in the logic. This plugin should already work, just like the preview on the right!


### PR DESCRIPTION
Fixes minor typo in the [Use With Element UI](https://peachscript.github.io/vue-infinite-loading/guide/use-with-el-table.html#use-with-element-ui) docs section.

![image](https://user-images.githubusercontent.com/25644093/168416582-ab85552f-e61a-47f5-bec5-be2f2e6fd66e.png)
